### PR TITLE
feat(test):replace xerces by bouncycastle for unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
       <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.78.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/src/test/java/org/tron/common/zksnark/LibrustzcashTest.java
+++ b/src/test/java/org/tron/common/zksnark/LibrustzcashTest.java
@@ -1,8 +1,9 @@
 package org.tron.common.zksnark;
 
-import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
 import java.util.Arrays;
 import java.util.Random;
+
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -34,35 +35,35 @@ public class LibrustzcashTest {
   @Test
   public void librustzcashAskToAkTest() {
     byte[] ak = new byte[32];
-    byte[] ask = HexBin.decode("ecb7085ce03f3a5fd57e3329cbbde3fcce9e3a0d7a4c2d3c1441cd1837163d0b");
+    byte[] ask = Hex.decode("ecb7085ce03f3a5fd57e3329cbbde3fcce9e3a0d7a4c2d3c1441cd1837163d0b");
     LibrustzcashWrapper.getInstance().librustzcashAskToAk(ask, ak);
-    Assert.assertArrayEquals(HexBin.decode("0830552707e438f1e1da6c89afc6581d3b1b674a53991ba51895bf9a3447c12c"), ak);
+    Assert.assertArrayEquals(Hex.decode("0830552707e438f1e1da6c89afc6581d3b1b674a53991ba51895bf9a3447c12c"), ak);
 
     ask[0] = 0;
     LibrustzcashWrapper.getInstance().librustzcashAskToAk(ask, ak);
-    Assert.assertFalse(Arrays.equals(HexBin.decode("0830552707e438f1e1da6c89afc6581d3b1b674a53991ba51895bf9a3447c12c"), ak));
+    Assert.assertFalse(Arrays.equals(Hex.decode("0830552707e438f1e1da6c89afc6581d3b1b674a53991ba51895bf9a3447c12c"), ak));
 
     ask = randomByte(32);
     LibrustzcashWrapper.getInstance().librustzcashAskToAk(ask, ak);
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), ak));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), ak));
   }
 
   @Test
   public void librustzcashSaplingComputeNfTest() {
-    byte[] d = HexBin.decode("4c418cf65a7210d9b66588");
-    byte[] pkd = HexBin.decode("4f05edbf1abe79773a46dbf16f43aa05290225487b656413533c405272b9bd5d");
+    byte[] d = Hex.decode("4c418cf65a7210d9b66588");
+    byte[] pkd = Hex.decode("4f05edbf1abe79773a46dbf16f43aa05290225487b656413533c405272b9bd5d");
     long value = 99990000L;
-    byte[] rcm = HexBin.decode("0e6eb90683c2a3e2d6477c68766e19e2376d24802684e1e69bf15ef074b3c206");
-    byte[] ak = HexBin.decode("11b96c93a610b6cb04769f8df693d610b781374348b38939b3a109e317d0845d");
-    byte[] nk = HexBin.decode("be75a89935512d029fddcf7b93466a417deea17ceb641e8372731a7367ea0464");
+    byte[] rcm = Hex.decode("0e6eb90683c2a3e2d6477c68766e19e2376d24802684e1e69bf15ef074b3c206");
+    byte[] ak = Hex.decode("11b96c93a610b6cb04769f8df693d610b781374348b38939b3a109e317d0845d");
+    byte[] nk = Hex.decode("be75a89935512d029fddcf7b93466a417deea17ceb641e8372731a7367ea0464");
     long position = 10;
     byte[] result = new byte[32];
     LibrustzcashWrapper.getInstance().librustzcashSaplingComputeNf(d, pkd, value, rcm, ak, nk, position, result);
-    Assert.assertArrayEquals(HexBin.decode("7f22468cae810da22743f8f66278b690a729c70aa0ee88d6736d43b5ea29ddf1"), result);
+    Assert.assertArrayEquals(Hex.decode("7f22468cae810da22743f8f66278b690a729c70aa0ee88d6736d43b5ea29ddf1"), result);
 
     position = 100L;
     LibrustzcashWrapper.getInstance().librustzcashSaplingComputeNf(d, pkd, value, rcm, ak, nk, position, result);
-    Assert.assertFalse(Arrays.equals(HexBin.decode("7f22468cae810da22743f8f66278b690a729c70aa0ee88d6736d43b5ea29ddf1"), result));
+    Assert.assertFalse(Arrays.equals(Hex.decode("7f22468cae810da22743f8f66278b690a729c70aa0ee88d6736d43b5ea29ddf1"), result));
 
     for (long val : LONG_ARRAY) {
       byte[] result1 = new byte[32];
@@ -73,108 +74,108 @@ public class LibrustzcashTest {
       nk = randomByte(32);
       LibrustzcashWrapper.getInstance()
           .librustzcashSaplingComputeNf(d, pkd, val, rcm, ak, nk, position, result1);
-      Assert.assertTrue(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), result1));
+      Assert.assertTrue(Arrays.equals(Hex.decode(BYTE_32_EMPTY), result1));
     }
   }
 
   @Test
   public void librustzcashNskToNkTest() {
     byte[] nk = new byte[32];
-    byte[] nsk = HexBin.decode("f07e24db728fac4bd315c4f46c83494a469823a0c3b4fc6125e3c56a3d352a05");
+    byte[] nsk = Hex.decode("f07e24db728fac4bd315c4f46c83494a469823a0c3b4fc6125e3c56a3d352a05");
     LibrustzcashWrapper.getInstance().librustzcashNskToNk(nsk, nk);
-    Assert.assertArrayEquals(HexBin.decode("92424303a0c7a161ca581dd01b62e1cfa763ddf8b2c6ff15813ba069b3ede89f"), nk);
+    Assert.assertArrayEquals(Hex.decode("92424303a0c7a161ca581dd01b62e1cfa763ddf8b2c6ff15813ba069b3ede89f"), nk);
 
     nsk[0] = 0;
     LibrustzcashWrapper.getInstance().librustzcashNskToNk(nsk, nk);
-    Assert.assertFalse(Arrays.equals(HexBin.decode("92424303a0c7a161ca581dd01b62e1cfa763ddf8b2c6ff15813ba069b3ede89f"), nk));
+    Assert.assertFalse(Arrays.equals(Hex.decode("92424303a0c7a161ca581dd01b62e1cfa763ddf8b2c6ff15813ba069b3ede89f"), nk));
 
     nsk = randomByte(32);
     LibrustzcashWrapper.getInstance().librustzcashNskToNk(nsk, nk);
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), nk));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), nk));
   }
 
   @Test
   public void librustzcashSaplingGenerateRTest() {
     byte[] alpha = new byte[32];
     LibrustzcashWrapper.getInstance().librustzcashSaplingGenerateR(alpha);
-    Assert.assertFalse(Arrays.equals(alpha, HexBin.decode("0000000000000000000000000000000000000000000000000000000000000000")));
+    Assert.assertFalse(Arrays.equals(alpha, Hex.decode("0000000000000000000000000000000000000000000000000000000000000000")));
   }
 
   @Test
   public void librustzcashSaplingKaDerivepublicTest() {
-    byte[] d = HexBin.decode("5558c672a1852a5dcd254c");
+    byte[] d = Hex.decode("5558c672a1852a5dcd254c");
     byte[] epk = new byte[32];
-    byte[] esk = HexBin.decode("1d67753f5e305bc47cb0685cda86dc865599b89adb4767bfc9411bff08714601");
+    byte[] esk = Hex.decode("1d67753f5e305bc47cb0685cda86dc865599b89adb4767bfc9411bff08714601");
     LibrustzcashWrapper.getInstance().librustzcashSaplingKaDerivepublic(d, esk, epk);
-    Assert.assertArrayEquals(HexBin.decode("98d49ad63aba6e949e08bfd727a965e4862233c3c1c45de6355618abaa57a555"), epk);
+    Assert.assertArrayEquals(Hex.decode("98d49ad63aba6e949e08bfd727a965e4862233c3c1c45de6355618abaa57a555"), epk);
 
     d[0] = 0;
     LibrustzcashWrapper.getInstance().librustzcashSaplingKaDerivepublic(d, esk, epk);
-    Assert.assertFalse(Arrays.equals(HexBin.decode("98d49ad63aba6e949e08bfd727a965e4862233c3c1c45de6355618abaa57a555"), epk));
+    Assert.assertFalse(Arrays.equals(Hex.decode("98d49ad63aba6e949e08bfd727a965e4862233c3c1c45de6355618abaa57a555"), epk));
 
     d = randomByte(11);
     esk = randomByte(32);
     LibrustzcashWrapper.getInstance().librustzcashSaplingKaDerivepublic(d, esk, epk);
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), epk));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), epk));
   }
 
   @Test
   public void librustzcashCrhIvkTest() {
-    byte[] ak = HexBin.decode("0830552707e438f1e1da6c89afc6581d3b1b674a53991ba51895bf9a3447c12c");
-    byte[] nk = HexBin.decode("92424303a0c7a161ca581dd01b62e1cfa763ddf8b2c6ff15813ba069b3ede89f");
+    byte[] ak = Hex.decode("0830552707e438f1e1da6c89afc6581d3b1b674a53991ba51895bf9a3447c12c");
+    byte[] nk = Hex.decode("92424303a0c7a161ca581dd01b62e1cfa763ddf8b2c6ff15813ba069b3ede89f");
     byte[] ivk = new byte[32];
     LibrustzcashWrapper.getInstance().librustzcashCrhIvk(ak, nk, ivk);
-    Assert.assertArrayEquals(HexBin.decode("f0cfb482b380f196906e82a22bf9afa5ec324d5062c70639adbcd5f35c4f7b07"), ivk);
+    Assert.assertArrayEquals(Hex.decode("f0cfb482b380f196906e82a22bf9afa5ec324d5062c70639adbcd5f35c4f7b07"), ivk);
 
     nk[0] = 0;
     LibrustzcashWrapper.getInstance().librustzcashCrhIvk(ak, nk, ivk);
-    Assert.assertFalse(Arrays.equals(HexBin.decode("f0cfb482b380f196906e82a22bf9afa5ec324d5062c70639adbcd5f35c4f7b07"), ivk));
+    Assert.assertFalse(Arrays.equals(Hex.decode("f0cfb482b380f196906e82a22bf9afa5ec324d5062c70639adbcd5f35c4f7b07"), ivk));
 
     nk = randomByte(32);
     ak = randomByte(32);
     LibrustzcashWrapper.getInstance().librustzcashCrhIvk(ak, nk, ivk);
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), ivk));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), ivk));
   }
 
   @Test
   public void librustzcashSaplingKaAgreeTest() {
-    byte[] esk = HexBin.decode("49e83d29a922f83da17a08e4a6be84d5d007752c2394b66fed456c5ef2e82706");
-    byte[] pkd = HexBin.decode("11f3701326cda3e61bb83490ed3de05960d56985a4031a876d8c899345919843");
+    byte[] esk = Hex.decode("49e83d29a922f83da17a08e4a6be84d5d007752c2394b66fed456c5ef2e82706");
+    byte[] pkd = Hex.decode("11f3701326cda3e61bb83490ed3de05960d56985a4031a876d8c899345919843");
     byte[] dhsecret = new byte[32];
     LibrustzcashWrapper.getInstance().librustzcashSaplingKaAgree(pkd, esk, dhsecret);
-    Assert.assertArrayEquals(HexBin.decode("6d76e9881454e5f3e6991b042442e3e66d61dade7f10b9c5a89ba77bc24e3c6d"), dhsecret);
+    Assert.assertArrayEquals(Hex.decode("6d76e9881454e5f3e6991b042442e3e66d61dade7f10b9c5a89ba77bc24e3c6d"), dhsecret);
 
     esk[0] = 0;
     LibrustzcashWrapper.getInstance().librustzcashSaplingKaAgree(pkd, esk, dhsecret);
-    Assert.assertFalse(Arrays.equals(HexBin.decode("6d76e9881454e5f3e6991b042442e3e66d61dade7f10b9c5a89ba77bc24e3c6d"), dhsecret));
+    Assert.assertFalse(Arrays.equals(Hex.decode("6d76e9881454e5f3e6991b042442e3e66d61dade7f10b9c5a89ba77bc24e3c6d"), dhsecret));
 
     esk = randomByte(32);
     pkd = randomByte(32);
     LibrustzcashWrapper.getInstance().librustzcashSaplingKaAgree(pkd, esk, dhsecret);
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), dhsecret));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), dhsecret));
   }
 
   @Test
   public void librustzcashCheckDiversifierTest() {
-    System.out.println(Arrays.toString(HexBin.decode("55ed53f0d6550b472cdf38")));
-    boolean ret = LibrustzcashWrapper.getInstance().librustzcashCheckDiversifier(HexBin.decode("55ed53f0d6550b472cdf38"));
+    System.out.println(Arrays.toString(Hex.decode("55ed53f0d6550b472cdf38")));
+    boolean ret = LibrustzcashWrapper.getInstance().librustzcashCheckDiversifier(Hex.decode("55ed53f0d6550b472cdf38"));
     Assert.assertFalse(ret);
-    System.out.println(Arrays.toString(HexBin.decode("02D72D7702F90B0FE71165")));
-    ret = LibrustzcashWrapper.getInstance().librustzcashCheckDiversifier(HexBin.decode("02D72D7702F90B0FE71165"));
+    System.out.println(Arrays.toString(Hex.decode("02D72D7702F90B0FE71165")));
+    ret = LibrustzcashWrapper.getInstance().librustzcashCheckDiversifier(Hex.decode("02D72D7702F90B0FE71165"));
     Assert.assertTrue(ret);
   }
 
   @Test
   public void librustzcashIvkToPkdTest() {
-    byte[] ivk = HexBin.decode("f0cfb482b380f196906e82a22bf9afa5ec324d5062c70639adbcd5f35c4f7b07");
-    byte[] d = HexBin.decode("b4875a6d871b9c9dce4cad");
+    byte[] ivk = Hex.decode("f0cfb482b380f196906e82a22bf9afa5ec324d5062c70639adbcd5f35c4f7b07");
+    byte[] d = Hex.decode("b4875a6d871b9c9dce4cad");
     byte[] pkd = new byte[32];
     Assert.assertTrue(LibrustzcashWrapper.getInstance().librustzcashIvkToPkd(ivk, d, pkd));
-    Assert.assertArrayEquals(HexBin.decode("7eb89170c8003264e0d4001ab49dbb10bef32c4dac780f210dd70c0948d22634"), pkd);
+    Assert.assertArrayEquals(Hex.decode("7eb89170c8003264e0d4001ab49dbb10bef32c4dac780f210dd70c0948d22634"), pkd);
 
     d[0] = 0;
     Assert.assertTrue(LibrustzcashWrapper.getInstance().librustzcashIvkToPkd(ivk, d, pkd));
-    Assert.assertFalse(Arrays.equals(HexBin.decode("7eb89170c8003264e0d4001ab49dbb10bef32c4dac780f210dd70c0948d22634"), pkd));
+    Assert.assertFalse(Arrays.equals(Hex.decode("7eb89170c8003264e0d4001ab49dbb10bef32c4dac780f210dd70c0948d22634"), pkd));
 
     ivk = randomByte(32);
     d = randomByte(11);
@@ -184,22 +185,22 @@ public class LibrustzcashTest {
     } else {
       Assert.assertFalse(LibrustzcashWrapper.getInstance().librustzcashIvkToPkd(ivk, d, pkd));
     }
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), pkd));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), pkd));
   }
 
   @Test
   public void librustzcashSaplingComputeCmTest() {
-    byte[] diversifier = HexBin.decode("fc6eb90855700861de6639");
-    byte[] pkd = HexBin.decode("1abfbf64bc4934aaf7f29b9fea995e5a16e654e63dbe07db0ef035499d216e19");
+    byte[] diversifier = Hex.decode("fc6eb90855700861de6639");
+    byte[] pkd = Hex.decode("1abfbf64bc4934aaf7f29b9fea995e5a16e654e63dbe07db0ef035499d216e19");
     long value = 9990000000L;
-    byte[] r = HexBin.decode("08e3a2ff1101b628147125b786c757b483f1cf7c309f8a647055bfb1ca819c02");
+    byte[] r = Hex.decode("08e3a2ff1101b628147125b786c757b483f1cf7c309f8a647055bfb1ca819c02");
     byte[] cm = new byte[32];
     Assert.assertTrue(LibrustzcashWrapper.getInstance().librustzcashSaplingComputeCm(diversifier, pkd, value, r, cm));
-    Assert.assertArrayEquals(HexBin.decode("0481f3949ddcd8e3d5e8018893dbad3df2f6fd09b406acdf32a68a3032f37920"), cm);
+    Assert.assertArrayEquals(Hex.decode("0481f3949ddcd8e3d5e8018893dbad3df2f6fd09b406acdf32a68a3032f37920"), cm);
 
     value = 100L;
     Assert.assertTrue(LibrustzcashWrapper.getInstance().librustzcashSaplingComputeCm(diversifier, pkd, value, r, cm));
-    Assert.assertFalse(Arrays.equals(HexBin.decode("0481f3949ddcd8e3d5e8018893dbad3df2f6fd09b406acdf32a68a3032f37920"), cm));
+    Assert.assertFalse(Arrays.equals(Hex.decode("0481f3949ddcd8e3d5e8018893dbad3df2f6fd09b406acdf32a68a3032f37920"), cm));
 
     for (long val : LONG_ARRAY) {
       diversifier = randomByte(11);
@@ -207,21 +208,21 @@ public class LibrustzcashTest {
       r = randomByte(32);
       Assert.assertFalse(LibrustzcashWrapper.getInstance()
           .librustzcashSaplingComputeCm(diversifier, pkd, val, r, cm));
-      Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), cm));
+      Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), cm));
     }
   }
 
   @Test
   public void librustzcashSaplingSpendProofTest() {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingProvingCtxInit();
-    byte[] ak = HexBin.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
-    byte[] nsk = HexBin.decode("48ea637742229ee87b8ebffd435b27469bee46ecb7732a6e3fb27939d442c006");
-    byte[] d = HexBin.decode("f689bf97e2112cae82eb69");
-    byte[] rcm = HexBin.decode("bf4b2042e3e8c4a0b390e407a79a0b46e36eff4f7bb54b2349dbb0046ee21e02");
-    byte[] alpha = HexBin.decode("1ddfb37119459a9733b3d2b4df35e9b18964568d75e43d79c6cdf7c1052e0501");
+    byte[] ak = Hex.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
+    byte[] nsk = Hex.decode("48ea637742229ee87b8ebffd435b27469bee46ecb7732a6e3fb27939d442c006");
+    byte[] d = Hex.decode("f689bf97e2112cae82eb69");
+    byte[] rcm = Hex.decode("bf4b2042e3e8c4a0b390e407a79a0b46e36eff4f7bb54b2349dbb0046ee21e02");
+    byte[] alpha = Hex.decode("1ddfb37119459a9733b3d2b4df35e9b18964568d75e43d79c6cdf7c1052e0501");
     long value = 100L;
-    byte[] anchor = HexBin.decode("653088e8ec266047956c474b91b259ff4eaecf8d10ab4b0cac9e5f53747f5f17");
-    byte[] voucherPath = HexBin.decode("2020b2eed031d4d6a4f02a097f80b54cc1541d4163c6b6f5971f88b6e41d35c538142012935f14b676509b81eb49ef25f39269ed72309238b4c145803544b646dca62d20e1f34b034d4a3cd28557e2907ebf990c918f64ecb50a94f01d6fda5ca5c7ef722028e7b841dcbc47cceb69d7cb8d94245fb7cb2ba3a7a6bc18f13f945f7dbd6e2a20a5122c08ff9c161d9ca6fc462073396c7d7d38e8ee48cdb3bea7e2230134ed6a20d2e1642c9a462229289e5b0e3b7f9008e0301cbb93385ee0e21da2545073cb582016d6252968971a83da8521d65382e61f0176646d771c91528e3276ee45383e4a20fee0e52802cb0c46b1eb4d376c62697f4759f6c8917fa352571202fd778fd712204c6937d78f42685f84b43ad3b7b00f81285662f85c6a68ef11d62ad1a3ee0850200769557bc682b1bf308646fd0b22e648e8b9e98f57e29f5af40f6edb833e2c492008eeab0c13abd6069e6310197bf80f9c1ea6de78fd19cbae24d4a520e6cf3023208d5fa43e5a10d11605ac7430ba1f5d81fb1b68d29a640405767749e841527673206aca8448d8263e547d5ff2950e2ed3839e998d31cbc6ac9fd57bc6002b15921620cd1c8dbf6e3acc7a80439bc4962cf25b9dce7c896f3a5bd70803fc5a0e33cf00206edb16d01907b759977d7650dad7e3ec049af1a3d875380b697c862c9ec5d51c201ea6675f9551eeb9dfaaa9247bc9858270d3d3a4c5afa7177a984d5ed1be245120d6acdedf95f608e09fa53fb43dcd0990475726c5131210c9e5caeab97f0e642f20bd74b25aacb92378a871bf27d225cfc26baca344a1ea35fdd94510f3d157082c201b77dac4d24fb7258c3c528704c59430b630718bec486421837021cf75dab65120ec677114c27206f5debc1c1ed66f95e2b1885da5b7be3d736b1de98579473048204777c8776a3b1e69b73a62fa701fa4f7a6282d9aee2c7a6b82e7937d7081c23c20ba49b659fbd0b7334211ea6a9d9df185c757e70aa81da562fb912b84f49bce722043ff5457f13b926b61df552d4e402ee6dc1463f99a535f9a713439264d5b616b207b99abdc3730991cc9274727d7d82d28cb794edbc7034b4f0053ff7c4b68044420d6c639ac24b46bd19341c91b13fdcab31581ddaf7f1411336a271f3d0aa52813208ac9cf9c391e3fd42891d27238a81a8a5c1d3a72b1bcbea8cf44a58ce738961320912d82b2c2bca231f71efcf61737fbf0a08befa0416215aeef53e8bb6d23390a20e110de65c907b9dea4ae0bd83a4b0a51bea175646a64c12b4c9f931b2cb31b4920d8283386ef2ef07ebdbb4383c12a739a953a4d6e0d6fb1139a4036d693bfbb6c20ffe9fc03f18b176c998806439ff0bb8ad193afdb27b2ccbc88856916dd804e342062324ff2c329e99193a74d28a585a3c167a93bf41a255135529c913bd9b1e666207c3ea01a6e3a3d90cf59cd789e467044b5cd78eb2c84cc6816f960746d0e036c0200000000000000");
+    byte[] anchor = Hex.decode("653088e8ec266047956c474b91b259ff4eaecf8d10ab4b0cac9e5f53747f5f17");
+    byte[] voucherPath = Hex.decode("2020b2eed031d4d6a4f02a097f80b54cc1541d4163c6b6f5971f88b6e41d35c538142012935f14b676509b81eb49ef25f39269ed72309238b4c145803544b646dca62d20e1f34b034d4a3cd28557e2907ebf990c918f64ecb50a94f01d6fda5ca5c7ef722028e7b841dcbc47cceb69d7cb8d94245fb7cb2ba3a7a6bc18f13f945f7dbd6e2a20a5122c08ff9c161d9ca6fc462073396c7d7d38e8ee48cdb3bea7e2230134ed6a20d2e1642c9a462229289e5b0e3b7f9008e0301cbb93385ee0e21da2545073cb582016d6252968971a83da8521d65382e61f0176646d771c91528e3276ee45383e4a20fee0e52802cb0c46b1eb4d376c62697f4759f6c8917fa352571202fd778fd712204c6937d78f42685f84b43ad3b7b00f81285662f85c6a68ef11d62ad1a3ee0850200769557bc682b1bf308646fd0b22e648e8b9e98f57e29f5af40f6edb833e2c492008eeab0c13abd6069e6310197bf80f9c1ea6de78fd19cbae24d4a520e6cf3023208d5fa43e5a10d11605ac7430ba1f5d81fb1b68d29a640405767749e841527673206aca8448d8263e547d5ff2950e2ed3839e998d31cbc6ac9fd57bc6002b15921620cd1c8dbf6e3acc7a80439bc4962cf25b9dce7c896f3a5bd70803fc5a0e33cf00206edb16d01907b759977d7650dad7e3ec049af1a3d875380b697c862c9ec5d51c201ea6675f9551eeb9dfaaa9247bc9858270d3d3a4c5afa7177a984d5ed1be245120d6acdedf95f608e09fa53fb43dcd0990475726c5131210c9e5caeab97f0e642f20bd74b25aacb92378a871bf27d225cfc26baca344a1ea35fdd94510f3d157082c201b77dac4d24fb7258c3c528704c59430b630718bec486421837021cf75dab65120ec677114c27206f5debc1c1ed66f95e2b1885da5b7be3d736b1de98579473048204777c8776a3b1e69b73a62fa701fa4f7a6282d9aee2c7a6b82e7937d7081c23c20ba49b659fbd0b7334211ea6a9d9df185c757e70aa81da562fb912b84f49bce722043ff5457f13b926b61df552d4e402ee6dc1463f99a535f9a713439264d5b616b207b99abdc3730991cc9274727d7d82d28cb794edbc7034b4f0053ff7c4b68044420d6c639ac24b46bd19341c91b13fdcab31581ddaf7f1411336a271f3d0aa52813208ac9cf9c391e3fd42891d27238a81a8a5c1d3a72b1bcbea8cf44a58ce738961320912d82b2c2bca231f71efcf61737fbf0a08befa0416215aeef53e8bb6d23390a20e110de65c907b9dea4ae0bd83a4b0a51bea175646a64c12b4c9f931b2cb31b4920d8283386ef2ef07ebdbb4383c12a739a953a4d6e0d6fb1139a4036d693bfbb6c20ffe9fc03f18b176c998806439ff0bb8ad193afdb27b2ccbc88856916dd804e342062324ff2c329e99193a74d28a585a3c167a93bf41a255135529c913bd9b1e666207c3ea01a6e3a3d90cf59cd789e467044b5cd78eb2c84cc6816f960746d0e036c0200000000000000");
 
     byte[] cv = new byte[32];
     byte[] rk = new byte[32];
@@ -230,7 +231,7 @@ public class LibrustzcashTest {
     Assert.assertTrue(LibrustzcashWrapper.getInstance().librustzcashSaplingSpendProof(
         ctx, ak, nsk, d, rcm, alpha, value, anchor, voucherPath, cv, rk, zkproof));
 
-    nsk = HexBin.decode("e65f967ab3a461b3a90aab555ed4c9b89f5c5cf197c7ee94c06f85fde6ef4107");
+    nsk = Hex.decode("e65f967ab3a461b3a90aab555ed4c9b89f5c5cf197c7ee94c06f85fde6ef4107");
     Assert.assertFalse(LibrustzcashWrapper.getInstance().librustzcashSaplingSpendProof(
         ctx, ak, nsk, d, rcm, alpha, value, anchor, voucherPath, cv, rk, zkproof));
 
@@ -252,13 +253,13 @@ public class LibrustzcashTest {
 
   @Test
   public void librustzcashCheckDiversifier() {
-    System.out.println(Arrays.toString(HexBin.decode("55ed53f0d6550b472cdf38")));
+    System.out.println(Arrays.toString(Hex.decode("55ed53f0d6550b472cdf38")));
     boolean ret = LibrustzcashWrapper.getInstance()
-        .librustzcashCheckDiversifier(HexBin.decode("55ed53f0d6550b472cdf38"));
+        .librustzcashCheckDiversifier(Hex.decode("55ed53f0d6550b472cdf38"));
     Assert.assertFalse(ret);
-    System.out.println(Arrays.toString(HexBin.decode("02D72D7702F90B0FE71165")));
+    System.out.println(Arrays.toString(Hex.decode("02D72D7702F90B0FE71165")));
     ret = LibrustzcashWrapper.getInstance()
-        .librustzcashCheckDiversifier(HexBin.decode("02D72D7702F90B0FE71165"));
+        .librustzcashCheckDiversifier(Hex.decode("02D72D7702F90B0FE71165"));
     Assert.assertTrue(ret);
   }
 
@@ -272,16 +273,16 @@ public class LibrustzcashTest {
 
   @Test
   public void librustzcashComputeCm() {
-    byte[] diversifier = HexBin.decode("0000000000000000000000");
-    byte[] pk_d = HexBin.decode("20001646fe036e09506e844a4acc668793a964cde6da3d5e2fd5f92c36546ba3");
+    byte[] diversifier = Hex.decode("0000000000000000000000");
+    byte[] pk_d = Hex.decode("20001646fe036e09506e844a4acc668793a964cde6da3d5e2fd5f92c36546ba3");
     long value = 40;
-    byte[] r = HexBin.decode("c7cd0ca6ad3c27cbea38e94575f221d0037d9076c4cf64cb37e9a72d657ad401");
+    byte[] r = Hex.decode("c7cd0ca6ad3c27cbea38e94575f221d0037d9076c4cf64cb37e9a72d657ad401");
     byte[] result = new byte[32];
     boolean ret = LibrustzcashWrapper.getInstance()
         .librustzcashSaplingComputeCm(diversifier, pk_d, value, r, result);
     Assert.assertFalse(ret);
 
-    byte[] pk_d2 = HexBin
+    byte[] pk_d2 = Hex
         .decode("2dc01646fe036e09506e844a4acc668793a964cde6da3d5e2fd5f92c36546ba3");
 
     boolean ret2 = LibrustzcashWrapper.getInstance()
@@ -294,19 +295,19 @@ public class LibrustzcashTest {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingProvingCtxInit();
     //generate spend proof
     {
-      byte[] ak = HexBin.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
-      byte[] nsk = HexBin
+      byte[] ak = Hex.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
+      byte[] nsk = Hex
           .decode("48ea637742229ee87b8ebffd435b27469bee46ecb7732a6e3fb27939d442c006");
 
-      byte[] d = HexBin.decode("5aafbda15b790d38637017");
+      byte[] d = Hex.decode("5aafbda15b790d38637017");
       long value = 10 * 1000000;
-      byte[] rcm = HexBin
+      byte[] rcm = Hex
           .decode("26328c28c46fb3c3a5e0648e5fc6b312a93f9fa93b5275cf79d4f71a30cd4d00");
-      byte[] alpha = HexBin
+      byte[] alpha = Hex
           .decode("994f6f29a8205747c510406e331d2a49faa1b517e630a4c55d9fe3856a9e030b");
-      byte[] anchor = HexBin
+      byte[] anchor = Hex
           .decode("f2097ce0e430f74a87d5d6c574f483165c781bd6b2423ec4824505890606554f");
-      byte[] voucherPath = HexBin.decode(
+      byte[] voucherPath = Hex.decode(
           "2020b2eed031d4d6a4f02a097f80b54cc1541d4163c6b6f5971f88b6e41d35c538142012935f14b676509b81eb49ef25f39269ed72309238b4c145803544b646dca62d20e1f34b034d4a3cd28557e2907ebf990c918f64ecb50a94f01d6fda5ca5c7ef722028e7b841dcbc47cceb69d7cb8d94245fb7cb2ba3a7a6bc18f13f945f7dbd6e2a20a5122c08ff9c161d9ca6fc462073396c7d7d38e8ee48cdb3bea7e2230134ed6a20d2e1642c9a462229289e5b0e3b7f9008e0301cbb93385ee0e21da2545073cb582016d6252968971a83da8521d65382e61f0176646d771c91528e3276ee45383e4a20fee0e52802cb0c46b1eb4d376c62697f4759f6c8917fa352571202fd778fd712204c6937d78f42685f84b43ad3b7b00f81285662f85c6a68ef11d62ad1a3ee0850200769557bc682b1bf308646fd0b22e648e8b9e98f57e29f5af40f6edb833e2c492008eeab0c13abd6069e6310197bf80f9c1ea6de78fd19cbae24d4a520e6cf3023208d5fa43e5a10d11605ac7430ba1f5d81fb1b68d29a640405767749e841527673206aca8448d8263e547d5ff2950e2ed3839e998d31cbc6ac9fd57bc6002b15921620cd1c8dbf6e3acc7a80439bc4962cf25b9dce7c896f3a5bd70803fc5a0e33cf00206edb16d01907b759977d7650dad7e3ec049af1a3d875380b697c862c9ec5d51c201ea6675f9551eeb9dfaaa9247bc9858270d3d3a4c5afa7177a984d5ed1be245120d6acdedf95f608e09fa53fb43dcd0990475726c5131210c9e5caeab97f0e642f20bd74b25aacb92378a871bf27d225cfc26baca344a1ea35fdd94510f3d157082c201b77dac4d24fb7258c3c528704c59430b630718bec486421837021cf75dab65120ec677114c27206f5debc1c1ed66f95e2b1885da5b7be3d736b1de98579473048204777c8776a3b1e69b73a62fa701fa4f7a6282d9aee2c7a6b82e7937d7081c23c20ba49b659fbd0b7334211ea6a9d9df185c757e70aa81da562fb912b84f49bce722043ff5457f13b926b61df552d4e402ee6dc1463f99a535f9a713439264d5b616b207b99abdc3730991cc9274727d7d82d28cb794edbc7034b4f0053ff7c4b68044420d6c639ac24b46bd19341c91b13fdcab31581ddaf7f1411336a271f3d0aa52813208ac9cf9c391e3fd42891d27238a81a8a5c1d3a72b1bcbea8cf44a58ce738961320912d82b2c2bca231f71efcf61737fbf0a08befa0416215aeef53e8bb6d23390a20e110de65c907b9dea4ae0bd83a4b0a51bea175646a64c12b4c9f931b2cb31b4920d8283386ef2ef07ebdbb4383c12a739a953a4d6e0d6fb1139a4036d693bfbb6c20ffe9fc03f18b176c998806439ff0bb8ad193afdb27b2ccbc88856916dd804e3420817de36ab2d57feb077634bca77819c8e0bd298c04f6fed0e6a83cc1356ca1552001000000000000000000000000000000000000000000000000000000000000000000000000000000");
       byte[] cv = new byte[32];
       byte[] rk = new byte[32];
@@ -329,12 +330,12 @@ public class LibrustzcashTest {
     }
     //generate output proof
     {
-      byte[] esk = HexBin
+      byte[] esk = Hex
           .decode("a5e43cbfc344872d1c4c54d16ea11aeb3031925b2afcbdc84ffeddde644bce06");
-      byte[] d = HexBin.decode("0000000000000000000000");
-      byte[] pkD = HexBin
+      byte[] d = Hex.decode("0000000000000000000000");
+      byte[] pkD = Hex
           .decode("a071d91f1d86ceffd5f19ad4187333ee820a4e018656e16380404e0c1696b9d8");
-      byte[] rcm = HexBin
+      byte[] rcm = Hex
           .decode("95d90bb5efb179a739949293c81861821860678de7afa9a241588e414ebd7707");
 
       long value = 1000000;
@@ -355,7 +356,7 @@ public class LibrustzcashTest {
     //create binding sig
     {
       long valueBalance = 9000000;
-      byte[] sighash = HexBin
+      byte[] sighash = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       byte[] result = new byte[64];
       boolean ret = LibrustzcashWrapper.getInstance()
@@ -366,10 +367,10 @@ public class LibrustzcashTest {
 
     // create spend sig
     {
-      byte[] ak = HexBin.decode("a12362562419d519ae4c53e40622af451a3f134d10edf499baaa2e4fd3c75204");
-      byte[] alpha = HexBin
+      byte[] ak = Hex.decode("a12362562419d519ae4c53e40622af451a3f134d10edf499baaa2e4fd3c75204");
+      byte[] alpha = Hex
           .decode("994f6f29a8205747c510406e331d2a49faa1b517e630a4c55d9fe3856a9e030b");
-      byte[] SigHash = HexBin
+      byte[] SigHash = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       byte[] result = new byte[64];
       boolean ret = LibrustzcashWrapper.getInstance()
@@ -383,16 +384,16 @@ public class LibrustzcashTest {
     ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingVerificationCtxInit();
     // check spend proof
     {
-      byte[] cv = HexBin.decode("e7a0d3dd2dfcac201a9d6d048275120ebe772a186dcc54c59126ed46b4d3ac2b");
-      byte[] Anchor = HexBin
+      byte[] cv = Hex.decode("e7a0d3dd2dfcac201a9d6d048275120ebe772a186dcc54c59126ed46b4d3ac2b");
+      byte[] Anchor = Hex
           .decode("f2097ce0e430f74a87d5d6c574f483165c781bd6b2423ec4824505890606554f");
-      byte[] nf = HexBin.decode("f5c35350812bb75c8607e0283fe8c32bb92a529a025bd3f74ebb9bf89ac52348");
-      byte[] rk = HexBin.decode("2b1c55975c854c1922330bea5786536a97d5b2b10b77b503b506b07e7b09ac22");
-      byte[] zkproof = HexBin.decode(
+      byte[] nf = Hex.decode("f5c35350812bb75c8607e0283fe8c32bb92a529a025bd3f74ebb9bf89ac52348");
+      byte[] rk = Hex.decode("2b1c55975c854c1922330bea5786536a97d5b2b10b77b503b506b07e7b09ac22");
+      byte[] zkproof = Hex.decode(
           "8c01e0be140fbe19d6a54469993a06af6b7cb3dc432c3f96479642d0319cc304bd4de106c5ef682d0ed313c9fdae3308a319089650d7e92ad6180d2a4a9fa057c662b8bd2dffd74447fde4cca0c94e00e8c76c5beb0ef6893f67b86aae03dfec197e63326803633c264a8f683a0c1131ff25a2d9f9bff97a6011d986fb73925ec523f9edfcc645fe3b787919e4c47f838a3fd1b04682c1c3ab2f8c6f369d8c74712ca74ed28bc7f723d466a5830d0b18eefa58a9cf7f242c4d29047674bc3eff");
-      byte[] spendAuthSig = HexBin.decode(
+      byte[] spendAuthSig = Hex.decode(
           "30dc7662f0621cbb4c4a93e8624b73ce6d110b4af6e9ec671e3072db6474339fa869c30020588c11c1ff5b268b183505d059f7870df4e223b7a73c18c3a07704");
-      byte[] SighashValue = HexBin
+      byte[] SighashValue = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       boolean ret = LibrustzcashWrapper.getInstance()
           .librustzcashSaplingCheckSpend(ctx, cv, Anchor, nf, rk, zkproof, spendAuthSig,
@@ -401,11 +402,11 @@ public class LibrustzcashTest {
     }
     // check output proof
     {
-      byte[] cv = HexBin.decode("b0faa6cc45d91d8fa0f17e0448459e3776ffb22556b1e33f5327127f471c5a8f");
-      byte[] cm = HexBin.decode("01aa431f8bfe25f276240f9dd68fc173e5ec71f749343a3f2b0f6357703ed84c");
-      byte[] EphemeralKey = HexBin
+      byte[] cv = Hex.decode("b0faa6cc45d91d8fa0f17e0448459e3776ffb22556b1e33f5327127f471c5a8f");
+      byte[] cm = Hex.decode("01aa431f8bfe25f276240f9dd68fc173e5ec71f749343a3f2b0f6357703ed84c");
+      byte[] EphemeralKey = Hex
           .decode("36c787daee6dd8dcff688b1dda8188cc9554d668dcb8e343cd2d10c9005bb305");
-      byte[] zkproof = HexBin.decode(
+      byte[] zkproof = Hex.decode(
           "81acc51e1a35d1947ce66e5bfa0d4c4896fa4b4a54ec33ab1af451686ea7eda45ad1c41dcee745f590396dfb983c895aaf8fd10188e06246c4d1fcf273e40ad5caa6ca9f1f2dbede1c7b13a23154de15dbb8fc812daa2c70362fa1f02c9b133e090b2ed57fadb58f8c4e190670b0da51ad126964a0124dcc3fcae66417c3a82be69f4fa7184d2aa48044186f5deb7ccb88213f56fa5cc61be2b2616eba88f51c608d6a8d684b1368a8c863394a34b9937b859f0078752f31fd295401f79f6fc3");
       boolean ret = LibrustzcashWrapper.getInstance()
           .librustzcashSaplingCheckOutput(ctx, cv, cm, EphemeralKey, zkproof);
@@ -413,9 +414,9 @@ public class LibrustzcashTest {
     }
     // FinalCheck
     {
-      byte[] bindingSig = HexBin.decode(
+      byte[] bindingSig = Hex.decode(
           "a52f10b92e15ba3783cc9ca1ebb4dd2aa700fb6da03ebffec7e4f9b46f2159d5ee7753100d4c10084ccdb0c2a2ad2ab6d068cce4bb87270323807641d937c50d");
-      byte[] sighashValue = HexBin
+      byte[] sighashValue = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       long valueBalance = 9000000L;
       boolean ret = LibrustzcashWrapper.getInstance()
@@ -428,19 +429,19 @@ public class LibrustzcashTest {
   @Test
   public void librustzcashSpendProofWrong() {
 
-    byte[] ak = HexBin.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
-    byte[] nsk = HexBin
+    byte[] ak = Hex.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
+    byte[] nsk = Hex
         .decode("48ea637742229ee87b8ebffd435b27469bee46ecb7732a6e3fb27939d442c006");
 
-    byte[] d = HexBin.decode("0000000000000000000000");
+    byte[] d = Hex.decode("0000000000000000000000");
     long value = 100;
-    byte[] rcm = HexBin
+    byte[] rcm = Hex
         .decode("d41c1e0da8e4c5cf8d9735db7d8a8333efc48c8efe90d722880ba659d6b13e00");
-    byte[] alpha = HexBin
+    byte[] alpha = Hex
         .decode("1a0f72740973302408118db5a457d77848baa6c25439d1a33bcf8f376ef3120b");
-    byte[] anchor = HexBin
+    byte[] anchor = Hex
         .decode("53cc21e123a0b6009f3f09ef6152027d81e84a83ce516da9b4720a7689435c42");
-    byte[] voucherPath = HexBin.decode(
+    byte[] voucherPath = Hex.decode(
         "2020b2eed031d4d6a4f02a097f80b54cc1541d4163c6b6f5971f88b6e41d35c538142012935f14b676509b81eb49ef25f39269ed72309238b4c145803544b646dca62d20e1f34b034d4a3cd28557e2907ebf990c918f64ecb50a94f01d6fda5ca5c7ef722028e7b841dcbc47cceb69d7cb8d94245fb7cb2ba3a7a6bc18f13f945f7dbd6e2a20a5122c08ff9c161d9ca6fc462073396c7d7d38e8ee48cdb3bea7e2230134ed6a20d2e1642c9a462229289e5b0e3b7f9008e0301cbb93385ee0e21da2545073cb582016d6252968971a83da8521d65382e61f0176646d771c91528e3276ee45383e4a20fee0e52802cb0c46b1eb4d376c62697f4759f6c8917fa352571202fd778fd712204c6937d78f42685f84b43ad3b7b00f81285662f85c6a68ef11d62ad1a3ee0850200769557bc682b1bf308646fd0b22e648e8b9e98f57e29f5af40f6edb833e2c492008eeab0c13abd6069e6310197bf80f9c1ea6de78fd19cbae24d4a520e6cf3023208d5fa43e5a10d11605ac7430ba1f5d81fb1b68d29a640405767749e841527673206aca8448d8263e547d5ff2950e2ed3839e998d31cbc6ac9fd57bc6002b15921620cd1c8dbf6e3acc7a80439bc4962cf25b9dce7c896f3a5bd70803fc5a0e33cf00206edb16d01907b759977d7650dad7e3ec049af1a3d875380b697c862c9ec5d51c201ea6675f9551eeb9dfaaa9247bc9858270d3d3a4c5afa7177a984d5ed1be245120d6acdedf95f608e09fa53fb43dcd0990475726c5131210c9e5caeab97f0e642f20bd74b25aacb92378a871bf27d225cfc26baca344a1ea35fdd94510f3d157082c201b77dac4d24fb7258c3c528704c59430b630718bec486421837021cf75dab65120ec677114c27206f5debc1c1ed66f95e2b1885da5b7be3d736b1de98579473048204777c8776a3b1e69b73a62fa701fa4f7a6282d9aee2c7a6b82e7937d7081c23c20ba49b659fbd0b7334211ea6a9d9df185c757e70aa81da562fb912b84f49bce722043ff5457f13b926b61df552d4e402ee6dc1463f99a535f9a713439264d5b616b207b99abdc3730991cc9274727d7d82d28cb794edbc7034b4f0053ff7c4b68044420d6c639ac24b46bd19341c91b13fdcab31581ddaf7f1411336a271f3d0aa52813208ac9cf9c391e3fd42891d27238a81a8a5c1d3a72b1bcbea8cf44a58ce738961320912d82b2c2bca231f71efcf61737fbf0a08befa0416215aeef53e8bb6d23390a20e110de65c907b9dea4ae0bd83a4b0a51bea175646a64c12b4c9f931b2cb31b4920d8283386ef2ef07ebdbb4383c12a739a953a4d6e0d6fb1139a4036d693bfbb6c20ffe9fc03f18b176c998806439ff0bb8ad193afdb27b2ccbc88856916dd804e3420817de36ab2d57feb077634bca77819c8e0bd298c04f6fed0e6a83cc1356ca1552001000000000000000000000000000000000000000000000000000000000000000000000000000000");
     byte[] cv = new byte[32];
     byte[] rk = new byte[32];
@@ -491,12 +492,12 @@ public class LibrustzcashTest {
   public void librustzcashOutputProofWrong() {
 
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingProvingCtxInit();
-    byte[] esk = HexBin
+    byte[] esk = Hex
         .decode("a5e43cbfc344872d1c4c54d16ea11aeb3031925b2afcbdc84ffeddde644bce06");
-    byte[] d = HexBin.decode("0000000000000000000000");
-    byte[] pkD = HexBin
+    byte[] d = Hex.decode("0000000000000000000000");
+    byte[] pkD = Hex
         .decode("1071d91f1d86ceffd5f19ad4187333ee820a4e018656e16380404e0c1696b9d8");
-    byte[] rcm = HexBin
+    byte[] rcm = Hex
         .decode("95d90bb5efb179a739949293c81861821860678de7afa9a241588e414ebd7707");
 
     long value = 1000000;
@@ -536,9 +537,9 @@ public class LibrustzcashTest {
   @Test
   public void librustzcashMerkleHash() {
     byte[] a =
-        HexBin.decode("05655316a07e6ec8c9769af54ef98b30667bfb6302b32987d552227dae86a087");
+        Hex.decode("05655316a07e6ec8c9769af54ef98b30667bfb6302b32987d552227dae86a087");
     byte[] b =
-        HexBin.decode("06041357de59ba64959d1b60f93de24dfe5ea1e26ed9e8a73d35b225a1845ba7");
+        Hex.decode("06041357de59ba64959d1b60f93de24dfe5ea1e26ed9e8a73d35b225a1845ba7");
 
     byte[] res = new byte[32];
     LibrustzcashWrapper.getInstance().librustzcashMerkleHash(4, a, b, res);
@@ -549,7 +550,7 @@ public class LibrustzcashTest {
       a = randomByte(32);
       b = randomByte(32);
       LibrustzcashWrapper.getInstance().librustzcashMerkleHash(val, a, b, res);
-      Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), res));
+      Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), res));
     }
   }
 
@@ -565,14 +566,14 @@ public class LibrustzcashTest {
   public void librustzcashToScalar() {
     byte[] res = new byte[32];
     byte[] tmp =
-        HexBin.decode("06041357de59ba64959d1b60f93de24dfe5ea1e26ed9e8a73d35b225a1845ba7");
+        Hex.decode("06041357de59ba64959d1b60f93de24dfe5ea1e26ed9e8a73d35b225a1845ba7");
 
     LibrustzcashWrapper.getInstance().librustzcashToScalar(tmp, res);
     Assert.assertFalse(Arrays.equals(res, new byte[32]));
 
     tmp = randomByte(32);
     LibrustzcashWrapper.getInstance().librustzcashToScalar(tmp, res);
-    Assert.assertFalse(Arrays.equals(HexBin.decode(BYTE_32_EMPTY), res));
+    Assert.assertFalse(Arrays.equals(Hex.decode(BYTE_32_EMPTY), res));
   }
 
   @Test
@@ -582,7 +583,7 @@ public class LibrustzcashTest {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingProvingCtxInit();
 
     long valueBalance = 9000000;
-    byte[] sighash = HexBin
+    byte[] sighash = Hex
         .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
     byte[] result = new byte[64];
     boolean ret = LibrustzcashWrapper.getInstance()
@@ -609,16 +610,16 @@ public class LibrustzcashTest {
   //check spend proof
   {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingVerificationCtxInit();
-    byte[] cv = HexBin.decode("e7a0d3dd2dfcac201a9d6d048275120ebe772a186dcc54c59126ed46b4d3ac2b");
-    byte[] Anchor = HexBin
+    byte[] cv = Hex.decode("e7a0d3dd2dfcac201a9d6d048275120ebe772a186dcc54c59126ed46b4d3ac2b");
+    byte[] Anchor = Hex
         .decode("f2097ce0e430f74a87d5d6c574f483165c781bd6b2423ec4824505890606554f");
-    byte[] nf = HexBin.decode("f5c35350812bb75c8607e0283fe8c32bb92a529a025bd3f74ebb9bf89ac52348");
-    byte[] rk = HexBin.decode("2b1c55975c854c1922330bea5786536a97d5b2b10b77b503b506b07e7b09ac22");
-    byte[] zkproof = HexBin.decode(
+    byte[] nf = Hex.decode("f5c35350812bb75c8607e0283fe8c32bb92a529a025bd3f74ebb9bf89ac52348");
+    byte[] rk = Hex.decode("2b1c55975c854c1922330bea5786536a97d5b2b10b77b503b506b07e7b09ac22");
+    byte[] zkproof = Hex.decode(
         "8c01e0be140fbe19d6a54469993a06af6b7cb3dc432c3f96479642d0319cc304bd4de106c5ef682d0ed313c9fdae3308a319089650d7e92ad6180d2a4a9fa057c662b8bd2dffd74447fde4cca0c94e00e8c76c5beb0ef6893f67b86aae03dfec197e63326803633c264a8f683a0c1131ff25a2d9f9bff97a6011d986fb73925ec523f9edfcc645fe3b787919e4c47f838a3fd1b04682c1c3ab2f8c6f369d8c74712ca74ed28bc7f723d466a5830d0b18eefa58a9cf7f242c4d29047674bc3eff");
-    byte[] spendAuthSig = HexBin.decode(
+    byte[] spendAuthSig = Hex.decode(
         "30dc7662f0621cbb4c4a93e8624b73ce6d110b4af6e9ec671e3072db6474339fa869c30020588c11c1ff5b268b183505d059f7870df4e223b7a73c18c3a07704");
-    byte[] SighashValue = HexBin
+    byte[] SighashValue = Hex
         .decode("0e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
     boolean ret = LibrustzcashWrapper.getInstance()
         .librustzcashSaplingCheckSpend(ctx, cv, Anchor, nf, rk, zkproof, spendAuthSig,
@@ -642,11 +643,11 @@ public class LibrustzcashTest {
   // check output proof
   {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingVerificationCtxInit();
-    byte[] cv = HexBin.decode("b0faa6cc45d91d8fa0f17e0448459e3776ffb22556b1e33f5327127f471c5a8f");
-    byte[] cm = HexBin.decode("01aa431f8bfe25f276240f9dd68fc173e5ec71f749343a3f2b0f6357703ed84c");
-    byte[] EphemeralKey = HexBin
+    byte[] cv = Hex.decode("b0faa6cc45d91d8fa0f17e0448459e3776ffb22556b1e33f5327127f471c5a8f");
+    byte[] cm = Hex.decode("01aa431f8bfe25f276240f9dd68fc173e5ec71f749343a3f2b0f6357703ed84c");
+    byte[] EphemeralKey = Hex
         .decode("36c787daee6dd8dcff688b1dda8188cc9554d668dcb8e343cd2d10c9005bb305");
-    byte[] zkproof = HexBin.decode(
+    byte[] zkproof = Hex.decode(
         "01acc51e1a35d1947ce66e5bfa0d4c4896fa4b4a54ec33ab1af451686ea7eda45ad1c41dcee745f590396dfb983c895aaf8fd10188e06246c4d1fcf273e40ad5caa6ca9f1f2dbede1c7b13a23154de15dbb8fc812daa2c70362fa1f02c9b133e090b2ed57fadb58f8c4e190670b0da51ad126964a0124dcc3fcae66417c3a82be69f4fa7184d2aa48044186f5deb7ccb88213f56fa5cc61be2b2616eba88f51c608d6a8d684b1368a8c863394a34b9937b859f0078752f31fd295401f79f6fc3");
     boolean ret = LibrustzcashWrapper.getInstance()
         .librustzcashSaplingCheckOutput(ctx, cv, cm, EphemeralKey, zkproof);
@@ -668,9 +669,9 @@ public class LibrustzcashTest {
   // FinalCheck
   {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingVerificationCtxInit();
-    byte[] bindingSig = HexBin.decode(
+    byte[] bindingSig = Hex.decode(
         "a52f10b92e15ba3783cc9ca1ebb4dd2aa700fb6da03ebffec7e4f9b46f2159d5ee7753100d4c10084ccdb0c2a2ad2ab6d068cce4bb87270323807641d937c50d");
-    byte[] sighashValue = HexBin
+    byte[] sighashValue = Hex
         .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
     long valueBalance = 9000000L;
     boolean ret = LibrustzcashWrapper.getInstance()
@@ -693,12 +694,12 @@ public class LibrustzcashTest {
   // FinalCheckNew
   {
     long valueBalance = 0L;
-    byte[] bindingSig = HexBin.decode(
+    byte[] bindingSig = Hex.decode(
             "272eae1acb15bdcfef508083bfe26ec86ea3a4f8fa92fa282ece1a3e54560b119a76cc1d98749a8f258a881b4635ef3553049847ff2fe5558c3b990bb0860706");
-    byte[] sighashValue = HexBin
+    byte[] sighashValue = Hex
             .decode("cbe9b02601afc8346b375e54cea3a966a45f1843cd51224e3198f169a5755df1");
-    byte[] spendCv = HexBin.decode("648d4a3715480e01c629a4525f5050787e00f41225510ea5cfe6de9469b92824973c803055e01fd4b6411b2abf7b4bf98e4a822745c684bbafa9dea232c7a1da");
-    byte[] outputCv = HexBin.decode("a49d7642de7c239e6ff4061a8adfaaac02dc3206c5d1687a735fa7f83de5745f72910acabe5f958f798b70bfe8343ce3f478c0234ec2229c69ea165aaafb9b18");
+    byte[] spendCv = Hex.decode("648d4a3715480e01c629a4525f5050787e00f41225510ea5cfe6de9469b92824973c803055e01fd4b6411b2abf7b4bf98e4a822745c684bbafa9dea232c7a1da");
+    byte[] outputCv = Hex.decode("a49d7642de7c239e6ff4061a8adfaaac02dc3206c5d1687a735fa7f83de5745f72910acabe5f958f798b70bfe8343ce3f478c0234ec2229c69ea165aaafb9b18");
 
     boolean ret = LibrustzcashWrapper.getInstance()
             .librustzcashSaplingFinalCheckNew(valueBalance, bindingSig, sighashValue, spendCv, 64, outputCv, 64);
@@ -710,19 +711,19 @@ public class LibrustzcashTest {
     long ctx = LibrustzcashWrapper.getInstance().librustzcashSaplingProvingCtxInit();
     //generate spend proof
     {
-      byte[] ak = HexBin.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
-      byte[] nsk = HexBin
+      byte[] ak = Hex.decode("2021c369f4b901cc4f37d80eac2d676aa41beb2a2d835d5120005714bc687657");
+      byte[] nsk = Hex
           .decode("48ea637742229ee87b8ebffd435b27469bee46ecb7732a6e3fb27939d442c006");
 
-      byte[] d = HexBin.decode("5aafbda15b790d38637017");
+      byte[] d = Hex.decode("5aafbda15b790d38637017");
       long value = 10 * 1000000;
-      byte[] rcm = HexBin
+      byte[] rcm = Hex
           .decode("26328c28c46fb3c3a5e0648e5fc6b312a93f9fa93b5275cf79d4f71a30cd4d00");
-      byte[] alpha = HexBin
+      byte[] alpha = Hex
           .decode("994f6f29a8205747c510406e331d2a49faa1b517e630a4c55d9fe3856a9e030b");
-      byte[] anchor = HexBin
+      byte[] anchor = Hex
           .decode("f2097ce0e430f74a87d5d6c574f483165c781bd6b2423ec4824505890606554f");
-      byte[] voucherPath = HexBin.decode(
+      byte[] voucherPath = Hex.decode(
           "2020b2eed031d4d6a4f02a097f80b54cc1541d4163c6b6f5971f88b6e41d35c538142012935f14b676509b81eb49ef25f39269ed72309238b4c145803544b646dca62d20e1f34b034d4a3cd28557e2907ebf990c918f64ecb50a94f01d6fda5ca5c7ef722028e7b841dcbc47cceb69d7cb8d94245fb7cb2ba3a7a6bc18f13f945f7dbd6e2a20a5122c08ff9c161d9ca6fc462073396c7d7d38e8ee48cdb3bea7e2230134ed6a20d2e1642c9a462229289e5b0e3b7f9008e0301cbb93385ee0e21da2545073cb582016d6252968971a83da8521d65382e61f0176646d771c91528e3276ee45383e4a20fee0e52802cb0c46b1eb4d376c62697f4759f6c8917fa352571202fd778fd712204c6937d78f42685f84b43ad3b7b00f81285662f85c6a68ef11d62ad1a3ee0850200769557bc682b1bf308646fd0b22e648e8b9e98f57e29f5af40f6edb833e2c492008eeab0c13abd6069e6310197bf80f9c1ea6de78fd19cbae24d4a520e6cf3023208d5fa43e5a10d11605ac7430ba1f5d81fb1b68d29a640405767749e841527673206aca8448d8263e547d5ff2950e2ed3839e998d31cbc6ac9fd57bc6002b15921620cd1c8dbf6e3acc7a80439bc4962cf25b9dce7c896f3a5bd70803fc5a0e33cf00206edb16d01907b759977d7650dad7e3ec049af1a3d875380b697c862c9ec5d51c201ea6675f9551eeb9dfaaa9247bc9858270d3d3a4c5afa7177a984d5ed1be245120d6acdedf95f608e09fa53fb43dcd0990475726c5131210c9e5caeab97f0e642f20bd74b25aacb92378a871bf27d225cfc26baca344a1ea35fdd94510f3d157082c201b77dac4d24fb7258c3c528704c59430b630718bec486421837021cf75dab65120ec677114c27206f5debc1c1ed66f95e2b1885da5b7be3d736b1de98579473048204777c8776a3b1e69b73a62fa701fa4f7a6282d9aee2c7a6b82e7937d7081c23c20ba49b659fbd0b7334211ea6a9d9df185c757e70aa81da562fb912b84f49bce722043ff5457f13b926b61df552d4e402ee6dc1463f99a535f9a713439264d5b616b207b99abdc3730991cc9274727d7d82d28cb794edbc7034b4f0053ff7c4b68044420d6c639ac24b46bd19341c91b13fdcab31581ddaf7f1411336a271f3d0aa52813208ac9cf9c391e3fd42891d27238a81a8a5c1d3a72b1bcbea8cf44a58ce738961320912d82b2c2bca231f71efcf61737fbf0a08befa0416215aeef53e8bb6d23390a20e110de65c907b9dea4ae0bd83a4b0a51bea175646a64c12b4c9f931b2cb31b4920d8283386ef2ef07ebdbb4383c12a739a953a4d6e0d6fb1139a4036d693bfbb6c20ffe9fc03f18b176c998806439ff0bb8ad193afdb27b2ccbc88856916dd804e3420817de36ab2d57feb077634bca77819c8e0bd298c04f6fed0e6a83cc1356ca1552001000000000000000000000000000000000000000000000000000000000000000000000000000000");
       byte[] cv = new byte[32];
       byte[] rk = new byte[32];
@@ -745,12 +746,12 @@ public class LibrustzcashTest {
     }
     //generate output proof
     {
-      byte[] esk = HexBin
+      byte[] esk = Hex
           .decode("a5e43cbfc344872d1c4c54d16ea11aeb3031925b2afcbdc84ffeddde644bce06");
-      byte[] d = HexBin.decode("0000000000000000000000");
-      byte[] pkD = HexBin
+      byte[] d = Hex.decode("0000000000000000000000");
+      byte[] pkD = Hex
           .decode("a071d91f1d86ceffd5f19ad4187333ee820a4e018656e16380404e0c1696b9d8");
-      byte[] rcm = HexBin
+      byte[] rcm = Hex
           .decode("95d90bb5efb179a739949293c81861821860678de7afa9a241588e414ebd7707");
 
       long value = 1000000;
@@ -771,7 +772,7 @@ public class LibrustzcashTest {
     //create binding sig
     {
       long valueBalance = 9000000;
-      byte[] sighash = HexBin
+      byte[] sighash = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       byte[] result = new byte[64];
       boolean ret = LibrustzcashWrapper.getInstance()
@@ -782,10 +783,10 @@ public class LibrustzcashTest {
 
     // create spend sig
     {
-      byte[] ak = HexBin.decode("a12362562419d519ae4c53e40622af451a3f134d10edf499baaa2e4fd3c75204");
-      byte[] alpha = HexBin
+      byte[] ak = Hex.decode("a12362562419d519ae4c53e40622af451a3f134d10edf499baaa2e4fd3c75204");
+      byte[] alpha = Hex
           .decode("994f6f29a8205747c510406e331d2a49faa1b517e630a4c55d9fe3856a9e030b");
-      byte[] SigHash = HexBin
+      byte[] SigHash = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       byte[] result = new byte[64];
       boolean ret = LibrustzcashWrapper.getInstance()
@@ -798,16 +799,16 @@ public class LibrustzcashTest {
 
     // check spend proof
     {
-      byte[] cv = HexBin.decode("e7a0d3dd2dfcac201a9d6d048275120ebe772a186dcc54c59126ed46b4d3ac2b");
-      byte[] Anchor = HexBin
+      byte[] cv = Hex.decode("e7a0d3dd2dfcac201a9d6d048275120ebe772a186dcc54c59126ed46b4d3ac2b");
+      byte[] Anchor = Hex
           .decode("f2097ce0e430f74a87d5d6c574f483165c781bd6b2423ec4824505890606554f");
-      byte[] nf = HexBin.decode("f5c35350812bb75c8607e0283fe8c32bb92a529a025bd3f74ebb9bf89ac52348");
-      byte[] rk = HexBin.decode("2b1c55975c854c1922330bea5786536a97d5b2b10b77b503b506b07e7b09ac22");
-      byte[] zkproof = HexBin.decode(
+      byte[] nf = Hex.decode("f5c35350812bb75c8607e0283fe8c32bb92a529a025bd3f74ebb9bf89ac52348");
+      byte[] rk = Hex.decode("2b1c55975c854c1922330bea5786536a97d5b2b10b77b503b506b07e7b09ac22");
+      byte[] zkproof = Hex.decode(
           "8c01e0be140fbe19d6a54469993a06af6b7cb3dc432c3f96479642d0319cc304bd4de106c5ef682d0ed313c9fdae3308a319089650d7e92ad6180d2a4a9fa057c662b8bd2dffd74447fde4cca0c94e00e8c76c5beb0ef6893f67b86aae03dfec197e63326803633c264a8f683a0c1131ff25a2d9f9bff97a6011d986fb73925ec523f9edfcc645fe3b787919e4c47f838a3fd1b04682c1c3ab2f8c6f369d8c74712ca74ed28bc7f723d466a5830d0b18eefa58a9cf7f242c4d29047674bc3eff");
-      byte[] spendAuthSig = HexBin.decode(
+      byte[] spendAuthSig = Hex.decode(
           "30dc7662f0621cbb4c4a93e8624b73ce6d110b4af6e9ec671e3072db6474339fa869c30020588c11c1ff5b268b183505d059f7870df4e223b7a73c18c3a07704");
-      byte[] SighashValue = HexBin
+      byte[] SighashValue = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       boolean ret = LibrustzcashWrapper.getInstance()
                                        .librustzcashSaplingCheckSpendNew(cv, Anchor, nf, rk,
@@ -817,12 +818,12 @@ public class LibrustzcashTest {
 
       // check output proof
 
-      byte[] cv1 = HexBin.decode(
+      byte[] cv1 = Hex.decode(
           "b0faa6cc45d91d8fa0f17e0448459e3776ffb22556b1e33f5327127f471c5a8f");
-      byte[] cm = HexBin.decode("01aa431f8bfe25f276240f9dd68fc173e5ec71f749343a3f2b0f6357703ed84c");
-      byte[] EphemeralKey = HexBin
+      byte[] cm = Hex.decode("01aa431f8bfe25f276240f9dd68fc173e5ec71f749343a3f2b0f6357703ed84c");
+      byte[] EphemeralKey = Hex
           .decode("36c787daee6dd8dcff688b1dda8188cc9554d668dcb8e343cd2d10c9005bb305");
-      byte[] zkproof1 = HexBin.decode(
+      byte[] zkproof1 = Hex.decode(
           "81acc51e1a35d1947ce66e5bfa0d4c4896fa4b4a54ec33ab1af451686ea7eda45ad1c41dcee745f590396dfb983c895aaf8fd10188e06246c4d1fcf273e40ad5caa6ca9f1f2dbede1c7b13a23154de15dbb8fc812daa2c70362fa1f02c9b133e090b2ed57fadb58f8c4e190670b0da51ad126964a0124dcc3fcae66417c3a82be69f4fa7184d2aa48044186f5deb7ccb88213f56fa5cc61be2b2616eba88f51c608d6a8d684b1368a8c863394a34b9937b859f0078752f31fd295401f79f6fc3");
       boolean ret1 = LibrustzcashWrapper.getInstance()
                                         .librustzcashSaplingCheckOutputNew(cv1, cm, EphemeralKey,
@@ -831,9 +832,9 @@ public class LibrustzcashTest {
 
       // FinalCheck
 
-      byte[] bindingSig = HexBin.decode(
+      byte[] bindingSig = Hex.decode(
           "a52f10b92e15ba3783cc9ca1ebb4dd2aa700fb6da03ebffec7e4f9b46f2159d5ee7753100d4c10084ccdb0c2a2ad2ab6d068cce4bb87270323807641d937c50d");
-      byte[] sighashValue = HexBin
+      byte[] sighashValue = Hex
           .decode("2e99758548972a8e8822ad47fa1017ff72f06f3ff6a016851f45c398732bc50c");
       long valueBalance = 9000000L;
       boolean ret2 = LibrustzcashWrapper.getInstance().librustzcashSaplingFinalCheckNew(

--- a/src/test/java/org/tron/common/zksnark/LibsodiumTest.java
+++ b/src/test/java/org/tron/common/zksnark/LibsodiumTest.java
@@ -1,6 +1,6 @@
 package org.tron.common.zksnark;
 
-import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public class LibsodiumTest {
 		long state = instance.cryptoGenerichashBlake2BStateInit();
 		
 		byte t = 0x00;
-		byte[] sk = HexBin.decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+		byte[] sk = Hex.decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
 		byte[] ask = new byte[64];
 		byte[] blob = new byte[33];
 		System.arraycopy(sk, 0, blob, 0, 32);
@@ -65,7 +65,7 @@ public class LibsodiumTest {
 		instance.cryptoGenerichashBlake2BUpdate(state, blob, 33);
 		instance.cryptoGenerichashBlake2BFinal(state, ask, 64);
 		
-		Assert.assertArrayEquals(HexBin.decode("e1e61e6789fd867cf1556515a3aed68c76f691e3f3e6facb4fb3a9dc84bbdb7b5ab0ddd896907f683c41cc978ec1e9867c46a1be52e3047da2fc39e51f593f6c"),
+		Assert.assertArrayEquals(Hex.decode("e1e61e6789fd867cf1556515a3aed68c76f691e3f3e6facb4fb3a9dc84bbdb7b5ab0ddd896907f683c41cc978ec1e9867c46a1be52e3047da2fc39e51f593f6c"),
 				ask);
 	}
 	
@@ -74,7 +74,7 @@ public class LibsodiumTest {
 		long state = instance.cryptoGenerichashBlake2BStateInit();
 		
 		byte t = 0x01;
-		byte[] sk = HexBin.decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+		byte[] sk = Hex.decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
 		byte[] nsk = new byte[64];
 		byte[] blob = new byte[33];
 		System.arraycopy(sk, 0, blob, 0, 32);
@@ -85,7 +85,7 @@ public class LibsodiumTest {
 		instance.cryptoGenerichashBlake2BUpdate(state, blob, 33);
 		instance.cryptoGenerichashBlake2BFinal(state, nsk, 64);
 		
-		Assert.assertArrayEquals(HexBin.decode("72cc2d7a4c51d11e0322c44bcab25ea379925d06a6fbc955e24cc27fea7f956cd9b9fee0471a6c950ae2ebc015b1b8aad21e6da97447f03d00cbe92410ac8a22"),
+		Assert.assertArrayEquals(Hex.decode("72cc2d7a4c51d11e0322c44bcab25ea379925d06a6fbc955e24cc27fea7f956cd9b9fee0471a6c950ae2ebc015b1b8aad21e6da97447f03d00cbe92410ac8a22"),
 				nsk);
 	}
 	
@@ -94,7 +94,7 @@ public class LibsodiumTest {
 		long state = instance.cryptoGenerichashBlake2BStateInit();
 		
 		byte t = 0x02;
-		byte[] sk = HexBin.decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
+		byte[] sk = Hex.decode("ff2c06269315333a9207f817d2eca0ac555ca8f90196976324c7756504e7c9ee");
 		byte[] ovk = new byte[64];
 		byte[] blob = new byte[33];
 		System.arraycopy(sk, 0, blob, 0, 32);
@@ -105,13 +105,13 @@ public class LibsodiumTest {
 		instance.cryptoGenerichashBlake2BUpdate(state, blob, 33);
 		instance.cryptoGenerichashBlake2BFinal(state, ovk, 64);
 		
-		Assert.assertArrayEquals(HexBin.decode("a5d78d08a2450fcfd445bf260f8d35d130366a857ef40398121439d98eb84a8a0c934d89823282309fb3212488763bfe7c94e7e57dcab84060734fe45e74dc3a"),
+		Assert.assertArrayEquals(Hex.decode("a5d78d08a2450fcfd445bf260f8d35d130366a857ef40398121439d98eb84a8a0c934d89823282309fb3212488763bfe7c94e7e57dcab84060734fe45e74dc3a"),
 				ovk);
 	}
 	
 	@Test
 	public void testCryptoGenerichashBlake2BSaltPersonal(){
-		byte[] block = HexBin.decode("a5d78d08a2450fcfd445bf260f8d35d130366a857ef40398121439d98eb84a8a86e590debb08355db1fd611b57433abe0853ef8f777f6124ad4bebe4008e15ce87619091b2e7cb72d7912d2363890984307ccf9506c9f319d14e723b1b4ed71225db42bb79eecd05448e1be8ebb1ce6f333a1ff3e45e18985c954eb611a71e47");
+		byte[] block = Hex.decode("a5d78d08a2450fcfd445bf260f8d35d130366a857ef40398121439d98eb84a8a86e590debb08355db1fd611b57433abe0853ef8f777f6124ad4bebe4008e15ce87619091b2e7cb72d7912d2363890984307ccf9506c9f319d14e723b1b4ed71225db42bb79eecd05448e1be8ebb1ce6f333a1ff3e45e18985c954eb611a71e47");
 		byte[] ock = new byte[NOTEENCRYPTION_CIPHER_KEYSIZE];
 		byte[] personalization = new byte[crypto_generichash_blake2b_PERSONALBYTES];
 		byte[] temp = "Ztron_Derive_ock".getBytes();
@@ -124,15 +124,15 @@ public class LibsodiumTest {
 		) != 0) {
 			throw new RuntimeException("cryptoGenerichashBlake2BSaltPersonal function failure");
 		}
-		Assert.assertArrayEquals(HexBin.decode("1abde642b85656189e3b67196f3f18aa8856d7ede463d517b5ed800185732d9f"),
+		Assert.assertArrayEquals(Hex.decode("1abde642b85656189e3b67196f3f18aa8856d7ede463d517b5ed800185732d9f"),
 				ock);
 	}
 	
 	@Test
 	public void testCryptoAeadChacha20Poly1305IetfDecrypt(){
 		byte[] cipher_nonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
-		byte[] ock = HexBin.decode("1abde642b85656189e3b67196f3f18aa8856d7ede463d517b5ed800185732d9f");
-		byte[] OutCiphertext = HexBin.decode("29998e86fb13139e441e9a2ce8e9131aae53ed31e26baed7be73a2a7e3b007c019e56cb55b7852a187220ea92161712d1e2f88fa3337dd369cc44801169fcdbab8ad8003f14dfc656850b50418e06839");
+		byte[] ock = Hex.decode("1abde642b85656189e3b67196f3f18aa8856d7ede463d517b5ed800185732d9f");
+		byte[] OutCiphertext = Hex.decode("29998e86fb13139e441e9a2ce8e9131aae53ed31e26baed7be73a2a7e3b007c019e56cb55b7852a187220ea92161712d1e2f88fa3337dd369cc44801169fcdbab8ad8003f14dfc656850b50418e06839");
 		byte[] plaintext = new byte[ZC_OUTPLAINTEXT_SIZE];
 		//decrypt out by ock, get esk, pk_d
 		if (instance.cryptoAeadChacha20Poly1305IetfDecrypt(plaintext, null,
@@ -143,19 +143,19 @@ public class LibsodiumTest {
 				cipher_nonce, ock) != 0) {
 			throw new RuntimeException("cryptoAeadChacha20Poly1305IetfDecrypt function failure");
 		}
-		Assert.assertArrayEquals(HexBin.decode("8d05b9988cc9f4216cc086eb7e4fec033aafc108f5866b770bffba5a675bbb9994fd11a331169bbd2dea726ced59947c716358fa4d4b35ecf42d1d5ae18f6402"),
+		Assert.assertArrayEquals(Hex.decode("8d05b9988cc9f4216cc086eb7e4fec033aafc108f5866b770bffba5a675bbb9994fd11a331169bbd2dea726ced59947c716358fa4d4b35ecf42d1d5ae18f6402"),
 				plaintext);
 	}
 	
 	@Test
 	public void testCryptoAeadChacha20Poly1305IetfEncrypt(){
 		byte[] cipherNonce = new byte[crypto_aead_chacha20poly1305_IETF_NPUBBYTES];
-		byte[] k_enc = HexBin.decode("cf9961c91dcea84ffdd0ce54ae2d86f815c988275701b47585d64dbf2b1b11ee");
-		byte[] message = HexBin.decode("015aafbda15b790d38637017a00f00000000000083d36fd4c8eebec516c3a8ce2fe4832e01eb57bd7f9f9c9e0bd68cc69a5b0f06a357e71719903bd55db273738b68c16f01411f25ed190ba6d7e423f1f4652ec6c49a4f70dd8cdafc8f1bc5eeef59bb6836def5fa075d1a2bdd4af5a4af52efae47409cf5e19fd1a89f29fb89d0ad1f386bfefbc5a14cfcd78183d23465219ef0e0cfe347e4f046929c9e43104825ca1b0f4449bd6b2dc9623c40501a29dfd91277a487c48489bce90826123c33d57c19cadb3974a3d534b7d4408f6173e7c111916cca703599610bb406b2beceed5387dd10d778c7fae068bcddaf7941a2eb191ff81d6fbb97c10250bff130e6030ba3e2d87354a1aab08dea1f8edab0282452373d5d8e0cec6b4a5a5c5bbffd77aa4f5e6659e6355dc748821410876389b68b23b879a579c8a344479c6806b8c77f4e3f98ac0b19634b337744dce2f8db23fa237c7778e9be6a0f9cb06f76d478360e4e737c43a580125cd9d361f588e98c875b7234a56cf7f71df48859cb9996f4040a6aee420cd3a3001c2a905fce0cb9db65710c42494a800c50369da25a405e845bf1d87617704e556f2de5164fc9af9ac5f66b928cdec5bfb07e6973dc294089512cd36afa58aee34f0ae8586b92fd7d4b262868ca4d1addc34893a46445e97d01f8359226589269e4f9e4eb65e6872951d6ee16c841cece3633c3baf60a9ce970669b5c8f51cab9a8262554c40ac70558c50cb127ff04794278f0f7ca0eee4b89429148fde8eb57bf109a7db2ab0111");
+		byte[] k_enc = Hex.decode("cf9961c91dcea84ffdd0ce54ae2d86f815c988275701b47585d64dbf2b1b11ee");
+		byte[] message = Hex.decode("015aafbda15b790d38637017a00f00000000000083d36fd4c8eebec516c3a8ce2fe4832e01eb57bd7f9f9c9e0bd68cc69a5b0f06a357e71719903bd55db273738b68c16f01411f25ed190ba6d7e423f1f4652ec6c49a4f70dd8cdafc8f1bc5eeef59bb6836def5fa075d1a2bdd4af5a4af52efae47409cf5e19fd1a89f29fb89d0ad1f386bfefbc5a14cfcd78183d23465219ef0e0cfe347e4f046929c9e43104825ca1b0f4449bd6b2dc9623c40501a29dfd91277a487c48489bce90826123c33d57c19cadb3974a3d534b7d4408f6173e7c111916cca703599610bb406b2beceed5387dd10d778c7fae068bcddaf7941a2eb191ff81d6fbb97c10250bff130e6030ba3e2d87354a1aab08dea1f8edab0282452373d5d8e0cec6b4a5a5c5bbffd77aa4f5e6659e6355dc748821410876389b68b23b879a579c8a344479c6806b8c77f4e3f98ac0b19634b337744dce2f8db23fa237c7778e9be6a0f9cb06f76d478360e4e737c43a580125cd9d361f588e98c875b7234a56cf7f71df48859cb9996f4040a6aee420cd3a3001c2a905fce0cb9db65710c42494a800c50369da25a405e845bf1d87617704e556f2de5164fc9af9ac5f66b928cdec5bfb07e6973dc294089512cd36afa58aee34f0ae8586b92fd7d4b262868ca4d1addc34893a46445e97d01f8359226589269e4f9e4eb65e6872951d6ee16c841cece3633c3baf60a9ce970669b5c8f51cab9a8262554c40ac70558c50cb127ff04794278f0f7ca0eee4b89429148fde8eb57bf109a7db2ab0111");
 		byte[] ciphertext = new byte[ZC_ENCCIPHERTEXT_SIZE];
 		instance.cryptoAeadChacha20Poly1305IetfEncrypt(ciphertext, null, message,
 				ZC_ENCPLAINTEXT_SIZE, null, 0, null, cipherNonce, k_enc);
-		Assert.assertArrayEquals(HexBin.decode("261de089eb840f976828cd9e1307bf68f7f989b3f79588365cee1391ab341d2dbfb2969c577ed70dc4243937a136674f55fbd271d70e2fde8fec249ff9ba199036e701d3f993dbb443109ea8f3171779232fe8fc6c36ed9d4925d1344877ffe103b96324612ea97eecaedfeb3aad2f221ff5620a9b4fb5f7da3f06af67c08704e43e815f57f020310a661f593725c4a8ddd61cf5933d6f3ca0acc34e2d9a69be79055bfa6dfd8109d13355758e32efbb3c0fa9f9d1a99c589999f23055a54c3b13fe8dd8bcf7562509654932227525bbe2536c7ad3ae16f62390b69f4cd78dd777b1434a193b5cfb911b0bce4b762399667e73de2a3936916e5661886b476bf50564f7d3a909b875a46c215cc2170a1f33c6ad81cf9aabeaf05e8516abaa8b824aef6d1c12d1cbf8a7d06256f1e7a9ea4fdfd6648324ee4b6a0a16d7dfa88d1ba41451dec470ad87130b584b827a7731a981e474cefccab800e4d083ff7d71facf5da8d20c73f75b72106f5521094794cc325d68a3a37f59cc95df24512aae7abb472fed2116aa56ef26be584808f6f2039b07412670f21e142de1771396383976997015821a41a31e5e1229790779117c58f0b519d02f96a57d485455ffb0f3ae1f76c57e614cfa9c07532845b97e8472e01060c32d47a6538d989d717251bc9e7044d45b121ebf180e79cf4d7154d5a7c1342c2e42541bec4da04602ec6eedf92b6f64f13860ee5e74218ff41e638ca9fa10e75eb393a6a4790644284e9fe7fd2a898997dc3a8d8ede6e2a0fe861b437dfd8045b37e52770dc4aa0e860b6fd60c57650"),
+		Assert.assertArrayEquals(Hex.decode("261de089eb840f976828cd9e1307bf68f7f989b3f79588365cee1391ab341d2dbfb2969c577ed70dc4243937a136674f55fbd271d70e2fde8fec249ff9ba199036e701d3f993dbb443109ea8f3171779232fe8fc6c36ed9d4925d1344877ffe103b96324612ea97eecaedfeb3aad2f221ff5620a9b4fb5f7da3f06af67c08704e43e815f57f020310a661f593725c4a8ddd61cf5933d6f3ca0acc34e2d9a69be79055bfa6dfd8109d13355758e32efbb3c0fa9f9d1a99c589999f23055a54c3b13fe8dd8bcf7562509654932227525bbe2536c7ad3ae16f62390b69f4cd78dd777b1434a193b5cfb911b0bce4b762399667e73de2a3936916e5661886b476bf50564f7d3a909b875a46c215cc2170a1f33c6ad81cf9aabeaf05e8516abaa8b824aef6d1c12d1cbf8a7d06256f1e7a9ea4fdfd6648324ee4b6a0a16d7dfa88d1ba41451dec470ad87130b584b827a7731a981e474cefccab800e4d083ff7d71facf5da8d20c73f75b72106f5521094794cc325d68a3a37f59cc95df24512aae7abb472fed2116aa56ef26be584808f6f2039b07412670f21e142de1771396383976997015821a41a31e5e1229790779117c58f0b519d02f96a57d485455ffb0f3ae1f76c57e614cfa9c07532845b97e8472e01060c32d47a6538d989d717251bc9e7044d45b121ebf180e79cf4d7154d5a7c1342c2e42541bec4da04602ec6eedf92b6f64f13860ee5e74218ff41e638ca9fa10e75eb393a6a4790644284e9fe7fd2a898997dc3a8d8ede6e2a0fe861b437dfd8045b37e52770dc4aa0e860b6fd60c57650"),
 				ciphertext);
 	}
 }


### PR DESCRIPTION
`com.sun.org.apache.xerces.internal.impl.dv.util.HexBin` is a JDK internal class, replaced by bcprov-jdk18on `org.bouncycastle.util.encoders.Hex`